### PR TITLE
recheck for ads after largest contentful paint, too.

### DIFF
--- a/content.js
+++ b/content.js
@@ -27,5 +27,10 @@ function hideAd(ad) {
 // hide ads on page load
 document.addEventListener('load', () => getAds().forEach(hideAd));
 
+// oftentimes, tweets render after onload. LCP should catch them.
+new PerformanceObserver((entryList) => {
+  getAds().forEach(hideAd);
+}).observe({type: 'largest-contentful-paint', buffered: true});
+
 // re-check as user scrolls
 document.addEventListener('scroll', () => getAds().forEach(hideAd));


### PR DESCRIPTION
great extension. nice and simple. 

i noticed it often doesnt catch the top one, but this should mostly do it.


A more comprehensive solution then the 3 invocations would be a mutationobserver, but i think we can avoid going that route for the moment.
