### PR TITLE
feature - detect and remove "topic" insertion tweets

### DIFF
--- a/content.js
+++ b/content.js
@@ -2,13 +2,15 @@ var adsHidden = 0;
 var adSelector = "div[data-testid=placementTracking]";
 var trendSelector = "div[data-testid=trend]";
 var userSelector = "div[data-testid=UserCell]";
+var topicSelector = "div[data-testid=cellInnerDiv]"; // also: socialContext
 var sponsoredSvgPath = 'M20.75 2H3.25C2.007 2 1 3.007 1 4.25v15.5C1 20.993 2.007 22 3.25 22h17.5c1.243 0 2.25-1.007 2.25-2.25V4.25C23 3.007 21.993 2 20.75 2zM17.5 13.504c0 .483-.392.875-.875.875s-.875-.393-.875-.876V9.967l-7.547 7.546c-.17.17-.395.256-.62.256s-.447-.086-.618-.257c-.342-.342-.342-.896 0-1.237l7.547-7.547h-3.54c-.482 0-.874-.393-.874-.876s.392-.875.875-.875h5.65c.483 0 .875.39.875.874v5.65z';
+var topicSvgPath = 'M18.265 3.314c-3.45-3.45-9.07-3.45-12.52 0-3.45 3.44-3.45 9.06 0 12.51 1.5 1.49 3.43 2.38 5.51 2.56v4.14c0 .31.2.6.5.7.08.03.17.05.25.05.22 0 .44-.1.59-.29l6.49-8.11c2.63-3.49 2.27-8.47-.82-11.56zm-10.56 7.87c0-.41.33-.75.75-.75h4.05c.41 0 .75.34.75.75s-.34.75-.75.75h-4.05c-.42 0-.75-.34-.75-.75zm8.6-3.24c0 .42-.34.75-.75.75h-7.1c-.42 0-.75-.33-.75-.75 0-.41.33-.75.75-.75h7.1c.41 0 .75.34.75.75z';
 
 function getAds() {
   return Array.from(document.querySelectorAll('div')).filter(function(el) {
     var filteredAd;
 
-    if (el.getInnerHTML().includes(sponsoredSvgPath)) {
+    if (el.getInnerHTML().includes(sponsoredSvgPath) || el.getInnerHTML().includes(topicSvgPath)) {
       filteredAd = el;
     }
 
@@ -20,11 +22,14 @@ function hideAd(ad) {
   if (ad.closest(adSelector) !== null) { // Promoted tweets
     ad.closest(adSelector).remove();
     adsHidden += 1;
-  } else if (ad.closest(trendSelector) !== null) {
+  } else if (ad.closest(trendSelector) !== null) { // Sidebar trends
     ad.closest(trendSelector).remove();
     adsHidden += 1;
-  } else if (ad.closest(userSelector) !== null) {
+  } else if (ad.closest(userSelector) !== null) { // Suggested users
     ad.closest(userSelector).remove();
+    adsHidden += 1;
+  } else if (ad.closest(topicSelector) !== null) { // Topic tweets
+    ad.closest(topicSelector).remove();
     adsHidden += 1;
   }
   console.log('Twitter ads hidden: ', adsHidden.toString());


### PR DESCRIPTION
requested by Enzo, https://github.com/ryanckulp/twitter_ad_blocker/issues/20

in basic tests it works OK, but after quickly scrolling it appears to reset the twitter timeline. either the widget now deletes more divs than it should (e.g. an outer parent div, vs just tweets), or twitter is detect too much DOM manipulation.